### PR TITLE
Update raceTimes.js for VRS series

### DIFF
--- a/src/data/raceTimes.js
+++ b/src/data/raceTimes.js
@@ -292,7 +292,7 @@ export default [{
   // VRS Mazda (Fixed)
   seriesId: 274,
   everyTime: duration(1, 'hours'),
-  offset: duration(30, 'minutes')
+  offset: duration(0, 'minutes')
 }, {
   // Formula Renault 2.0
   seriesId: 269,


### PR DESCRIPTION
seriesId: 274 - change the offset to 0 minutes instead of 30 to start the race at the top of the hour for the VirtualRacingSchool MX5-fixed series.