### PR TITLE
Link directly to the sessions page

### DIFF
--- a/src/components/columns/Link.js
+++ b/src/components/columns/Link.js
@@ -11,7 +11,7 @@ export default class NextRace extends Component {
     return (
       <td>
         <a
-          href={`http://members.iracing.com/membersite/member/SeriesNews.do?season=${race.seasonId}`}
+          href={`http://members.iracing.com/membersite/member/SeriesSessions.do?season=${race.seasonId}`}
           target='_blank'>
           <span className='glyphicon glyphicon-link' />
         </a>


### PR DESCRIPTION
Proposed change to link directly to the sessions page on iRacing to enable users to easily join sessions from this page.

I don't think the SeriesNews page is very helpful.