### PR TITLE
Add missing race times

### DIFF
--- a/src/data/changelog.js
+++ b/src/data/changelog.js
@@ -1,6 +1,13 @@
 import moment from 'moment';
 
 export default [{
+  date: moment('2018-12-27 00:00:00').utc(),
+  items: [
+    'Added races times for Dallara F3',
+    'Added races times for Formula Renault 3.5',
+    'Added races times for Ferrari GT3 Challenge',
+  ]
+},{
   date: moment('2018-12-11 00:00:00').utc(),
   items: [
     'Update to 2019S1'

--- a/src/data/race-times/roadB.js
+++ b/src/data/race-times/roadB.js
@@ -35,4 +35,10 @@ export default [
     ],
     offWeeks: [1.5, 2.5, 3.5, 4.5, 5.5]
   },
+  {
+    // Formula Renault 3.5
+    seriesId: 359,
+    everyTime: duration(2, 'hours'),
+    offset: duration(0, 'minutes')
+  },
 ];

--- a/src/data/race-times/roadC.js
+++ b/src/data/race-times/roadC.js
@@ -81,5 +81,11 @@ export default [
       duration({ days: 5, hours: 17 }), // Sun 5pm
       duration({ days: 6, hours: 14 }) // Mon 2pm
     ]
+  },
+  {
+    // Dallara F3
+    seriesId: 358,
+    everyTime: duration(120, 'minutes'),
+    offset: duration(75, 'minutes')
   }
 ];

--- a/src/data/race-times/roadD.js
+++ b/src/data/race-times/roadD.js
@@ -33,5 +33,10 @@ export default [
       1.1, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.11, 3.1, 4.1, 4.2,
       4.3, 4.4, 4.5, 5.1, 6.1, 6.2, 7.1, 8.1
     ]
+  }, {
+    // Ferrari GT3 Challenge
+    seriesId: 353,
+    everyTime: duration(1, 'hours'),
+    offset: duration(30, 'minutes')
   }
 ];


### PR DESCRIPTION
Adds missing race times for new series: F3, FR3.5 and Ferrari GT3 Challenge.

Ferrari GT3 is listed as 15 minutes past every hour in the PDF but is actually 30 minutes past.

Fixes #21
