### PR TITLE
Set times Modal off by 1

### DIFF
--- a/src/components/columns/RaceTimes.js
+++ b/src/components/columns/RaceTimes.js
@@ -23,7 +23,7 @@ export default function NextRace({ race }: Props) {
   const { t } = useTranslation();
 
   if (race.setTimes) {
-    const weekStart = moment().utc().startOf('week').add(2, 'days');
+    const weekStart = moment(moment().utc()).subtract(1, 'days').startOf('isoWeek').add(1, 'days');
 
     return (
       <td className={styles.clickableCell}>


### PR DESCRIPTION
Have been absolutely loving the website - such a valuable tool for this community!

I discovered this small but simple bug when viewing events with set times (VRS Endurance was where I found it). The times were correct, however the day specified was off by 1.

I've adjusted the logic used for specifying the start of the week to be the same of that in `src/lib/races.js`.