### PR TITLE
Update purchaseOptimization.js to fix issue with track count in Purchase Guide modal

### DIFF
--- a/src/lib/purchaseOptimization.js
+++ b/src/lib/purchaseOptimization.js
@@ -32,7 +32,7 @@ export default function calulatePurchaseOptimization({
       [trackPkgId]: {
         track: resultMap[trackPkgId] ? resultMap[trackPkgId].track : originalTrack,
         series: resultMap[trackPkgId] ? resultMap[trackPkgId].series : fromSeries,
-        count: resultMap[trackPkgId] ? resultMap[trackPkgId].count + 1 : 0,
+        count: resultMap[trackPkgId] ? resultMap[trackPkgId].count + 1 : 1,
       },
     };
   }, {}));


### PR DESCRIPTION
Resolve issue with track count being incorrect. First occurrence was setting the count to 0 instead of 1.